### PR TITLE
Fix flaky test PolarPlotTest.testGetLegendItems2

### DIFF
--- a/src/main/java/org/jfree/chart/plot/PolarPlot.java
+++ b/src/main/java/org/jfree/chart/plot/PolarPlot.java
@@ -56,6 +56,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -258,7 +259,7 @@ public class PolarPlot extends Plot implements ValueAxisPlot, Zoomable,
         this.axisLocations.put(6, PolarAxisLocation.WEST_ABOVE);
         this.axisLocations.put(7, PolarAxisLocation.SOUTH_LEFT);
 
-        this.renderers = new HashMap<>();
+        this.renderers = new LinkedHashMap<>();
         this.renderers.put(0, renderer);
         if (renderer != null) {
             renderer.setPlot(this);


### PR DESCRIPTION
This PR aims to fix a test:
```
org.jfree.chart.plot.PolarPlotTest.testGetLegendItems2
```
This was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

The following command can be used to replicate the failures and validate the fix:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.jfree.chart.plot.PolarPlotTest#testGetLegendItems2
```

**Environment:**

> Java: openjdk version "11.0.20.1"
> Maven: Apache Maven 3.6.3

Encountered the following error after running NonDex:
```
in org.jfree.chart.plot.PolarPlotTest
[ERROR] org.jfree.chart.plot.PolarPlotTest.testGetLegendItems2  Time elapsed: 0.053 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <A> but was: <C>
at org.jfree.chart@2.0.0-SNAPSHOT/org.jfree.chart.plot.PolarPlotTest.testGetLegendItems2(PolarPlotTest.java:108)
```
**REASON AND FIX**

The tests fail when the function values of 'items' are compared using assert statements in`testGetLegendItems2`. This is because the 'renderers' in Plot are set using HashMap and maintains a non-deterministic order. 

https://github.com/Sujishark/jfreechart/blob/e2d6788d594c51941ddae337ae666fda5c52ad9f/src/test/java/org/jfree/chart/plot/PolarPlotTest.java#L103

https://github.com/Sujishark/jfreechart/blob/e2d6788d594c51941ddae337ae666fda5c52ad9f/src/main/java/org/jfree/chart/plot/PolarPlot.java#L261

According to [HashMap documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html),
*"This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time."*

Due to this, non-determinism occurs. This is solved by changing from HashMap to LinkedHashMap to maintain a permanent deterministic order.

https://github.com/Sujishark/jfreechart/blob/cc11c17f99f014f63d845c8976e33eae0e52bab2/src/main/java/org/jfree/chart/plot/PolarPlot.java#L262 
 
No user-facing change.
No dependency upgrade.

